### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+In most cases, all you need to do for a new release of CockroachDB is update the `url`, `version`, and `sha256` fields. To test, you can run `brew reinstall ./Formula/cockroach.rb`.
+
+There are tests available with `brew test ./Formula/cockroach.rb` and a linter with `brew audit --strict --online ./Formula/cockroach.rb`. 


### PR DESCRIPTION
Includes notes on the process for Cockroach Labs developers updating this repo for a release. This keeps the README.md focused on external users of the repo. 

The tests are currently broken, and tracked in #40 