### PR TITLE
Update homebrew formula for v20.2.3

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -1,9 +1,9 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  url "https://binaries.cockroachdb.com/cockroach-v20.2.2.darwin-10.9-amd64.tgz"
-  version "20.2.2"
-  sha256 "16a71f5a7adaa61fcc64cee0f556e14b357050230c8dd78e4c7d509eb6c93cce"
+  url "https://binaries.cockroachdb.com/cockroach-v20.2.3.darwin-10.9-amd64.tgz"
+  version "20.2.3"
+  sha256 "5fba2230b20166eedfa566185cb55759feb05ed9d9049ad302dae03d39e671a2"
 
 
   bottle :unneeded


### PR DESCRIPTION
The sha used in this commit was generated by:
```
$  echo $VERSION
v20.2.3
$  curl https://binaries.cockroachdb.com/cockroach-${VERSION}.darwin-10.9-amd64.tgz | shasum -a 256
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 52.2M  100 52.2M    0     0  32.4M      0  0:00:01  0:00:01 --:--:-- 32.4M

5fba2230b20166eedfa566185cb55759feb05ed9d9049ad302dae03d39e671a2  -
```