### PR TITLE
Update homebrew formula for v20.2.4

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -1,9 +1,9 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  url "https://binaries.cockroachdb.com/cockroach-v20.2.3.darwin-10.9-amd64.tgz"
-  version "20.2.3"
-  sha256 "5fba2230b20166eedfa566185cb55759feb05ed9d9049ad302dae03d39e671a2"
+  url "https://binaries.cockroachdb.com/cockroach-v20.2.4.darwin-10.9-amd64.tgz"
+  version "20.2.4"
+  sha256 "c03dc30d2edf134640cd161e58e36b5cafd8b53c824e71f8529e02cace006863"
 
 
   bottle :unneeded


### PR DESCRIPTION
SHA was generated by:
```bash
$  curl https://binaries.cockroachdb.com/cockroach-v20.2.4.darwin-10.9-amd64.tgz | shasum -a 256
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 53.1M  100 53.1M    0     0  27.4M      0  0:00:01  0:00:01 --:--:-- 27.3M
c03dc30d2edf134640cd161e58e36b5cafd8b53c824e71f8529e02cace006863  -
```