### PR TITLE
Removed deprecated bottle :unneeded

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -5,9 +5,6 @@ class Cockroach < Formula
   version "21.1.11"
   sha256 "b31cfc5e1e86e2e5ec9002cbb94c89aaf23bced71b343827fb22db02a673e64e"
 
-
-  bottle :unneeded
-
   def install
     bin.install "cockroach"
     lib.mkpath


### PR DESCRIPTION
Homebrew now issues following warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the cockroachdb/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/cockroachdb/homebrew-tap/Formula/cockroach.rb:9
```

Closes #84 