### PR TITLE
Simplify version bump process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Usage example: make VERSION 21.2.5
+
+ifndef VERSION
+$(error define VERSION)
+endif
+
+generate:
+	@cd release && \
+		go run main.go $(VERSION) > ../Formula/cockroach.rb

--- a/release/cockroach-tmpl.rb
+++ b/release/cockroach-tmpl.rb
@@ -4,9 +4,9 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  url "https://binaries.cockroachdb.com/cockroach-v21.2.5.darwin-10.9-amd64.tgz"
-  version "21.2.5"
-  sha256 "d149b0b9602c3d1ca69b90f8e3d7d2c91146eb76fe61279b5e28e363592f81cd"
+  url "{{ .URL }}"
+  version "{{ .Version }}"
+  sha256 "{{ .SHA256 }}"
 
   def install
     bin.install "cockroach"
@@ -122,4 +122,3 @@ class Cockroach < Formula
     end
   end
 end
-

--- a/release/main.go
+++ b/release/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/template"
+)
+
+type templateArgs struct {
+	Version string
+	URL     string
+	SHA256  string
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run main.go version")
+		os.Exit(1)
+	}
+	out, err := processTemplate(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+}
+
+func sha256FromURL(url string) (string, error) {
+	resp, err := http.DefaultClient.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("cannot download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	hasher := sha256.New()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, resp.Body); err != nil {
+		return "", fmt.Errorf("cannot copy: %w", err)
+	}
+	hasher.Write(buf.Bytes())
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func processTemplate(version string) (string, error) {
+	t, err := template.ParseFiles("cockroach-tmpl.rb")
+
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	url := fmt.Sprintf("https://binaries.cockroachdb.com/cockroach-v%s.darwin-10.9-amd64.tgz", version)
+	sha256, err := sha256FromURL(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate SHA256: %w", err)
+	}
+	data := templateArgs{
+		Version: version,
+		URL:     url,
+		SHA256:  sha256,
+	}
+	var buf bytes.Buffer
+	err = t.Execute(&buf, data)
+	if err != nil {
+		return "", fmt.Errorf("cannot execute template: %w", err)
+	}
+	return buf.String(), nil
+}


### PR DESCRIPTION
Previously we had to do some manual work to update the formula -
download the file to calculate the SHA256 checksum, update various
fields to reflect the changes. This has been error prone and not
automation friendly.

This patch add a simple helper which uses a template to generate the
brew formula.