### PR TITLE
Fix typo, strip possible "v" version prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Usage example: make VERSION 21.2.5
+# Usage example: make VERSION=21.2.5
 
 ifndef VERSION
 $(error define VERSION)


### PR DESCRIPTION
* Fixed typo in make usage.
* Trim possible "v" version prefix to be more resilient.
