### PR TITLE
Problem: cockroachdb can't locate libgeos.dylib when installed into /opt

### DIFF
--- a/release/cockroach-tmpl.rb
+++ b/release/cockroach-tmpl.rb
@@ -63,6 +63,7 @@ class Cockroach < Formula
         <string>#{opt_bin}/cockroach</string>
         <string>start-single-node</string>
         <string>--store=#{var}/cockroach/</string>
+        <string>--spatial-libs=#{lib}/cockroach</string>
         <string>--http-port=26256</string>
         <string>--insecure</string>
         <string>--host=localhost</string>


### PR DESCRIPTION
On Apple Silicon Macs homebrew packages get installed into /opt.
The default path used by cockroachdb for dynamic libraries points
to /usr/local. When starting the service via brew services the
cockroach binary can't locate the dynamic libraries unless we
add the --spatial-libs parameter to point it to the correct
library directory.