### PR TITLE
Bazelize bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 *.tmp
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,4 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# to regenerate BUILD files, run `bazel run //:gazelle`
+gazelle(name = "gazelle")

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ $(error define VERSION)
 endif
 
 generate:
-	@cd release && \
-		go run main.go $(PRODUCT) $(VERSION) > ../Formula/$(PRODUCT).rb.tmp && \
-		mv ../Formula/$(PRODUCT).rb.tmp ../Formula/$(PRODUCT).rb
+	bazel build //release && \
+	  $$(bazel info bazel-bin)/release/release_/release \
+	  $(PRODUCT) $(VERSION) release/$(PRODUCT)-tmpl.rb > Formula/$(PRODUCT).rb.tmp && \
+	  mv Formula/$(PRODUCT).rb.tmp Formula/$(PRODUCT).rb

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,28 @@
+workspace(name = "com_github_coachroachdb_homebrew_tap")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+go_rules_dependencies()
+go_register_toolchains(version = "1.18")
+gazelle_dependencies()

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "release_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/example/project/release",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "release",
+    embed = [":release_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/release/main.go
+++ b/release/main.go
@@ -26,13 +26,14 @@ type templateArgs struct {
 }
 
 func main() {
-	if len(os.Args) != 3 {
-		fmt.Println("Usage: go run main.go <cockroach|ccloud> <version>")
+	if len(os.Args) != 4 {
+		fmt.Println("Usage: go run main.go <cockroach|ccloud> <version> <template file>")
 		os.Exit(1)
 	}
 	product := os.Args[1]
 	version := strings.TrimPrefix(os.Args[2], "v")
-	out, err := processTemplate(product, version)
+	templateFile := os.Args[3]
+	out, err := processTemplate(product, version, templateFile)
 	if err != nil {
 		panic(err)
 	}
@@ -45,7 +46,7 @@ func sha256FromURL(url string) (string, error) {
 		return "", fmt.Errorf("cannot download: %w", err)
 	}
 	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		return "", fmt.Errorf("unexpected status code %d for %s", resp.StatusCode, url)
 	}
 	defer resp.Body.Close()
 
@@ -58,8 +59,8 @@ func sha256FromURL(url string) (string, error) {
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
-func processTemplate(product, version string) (string, error) {
-	t, err := template.ParseFiles(fmt.Sprintf("%s-tmpl.rb", product))
+func processTemplate(product, version string, templateFile string) (string, error) {
+	t, err := template.ParseFiles(templateFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse template: %w", err)
 	}


### PR DESCRIPTION
Previously, running the `generate` make target required Go
pre-installed. It is not the case in our Bazel CI images.

This PR adds Bazel support and builds the release version bumper binary
using Bazel before executing it. Also it explicitly passes the template
file to get rid of some compiled-in magic.