### PR TITLE
ccloud: update ccloud to v0.2.2

### DIFF
--- a/Formula/ccloud.rb
+++ b/Formula/ccloud.rb
@@ -4,9 +4,9 @@
 class Ccloud < Formula
   desc "CockroachDB Cloud CLI"
   homepage "https://www.cockroachlabs.com"
-  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.1.1.tar.gz"
-  version "0.1.1"
-  sha256 "65d41a0e3a82274aaeb63e7fe5f6f33209b02a711d9894ce4580f642f6be561e"
+  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.2.2.tar.gz"
+  version "0.2.2"
+  sha256 "6793f246805c6c4909de9dca47e8d88a0e7af72cca41087da86065f92684ccbb"
 
   def install
     bin.install "ccloud"
@@ -14,7 +14,7 @@ class Ccloud < Formula
 
   test do
     output = shell_output("#{bin}/ccloud version", 0)
-    assert_match "ccloud 0.1.1", output
+    assert_match "ccloud 0.2.2", output
   end
 end
 


### PR DESCRIPTION
`ccloud` is being updated to utilize v0.2.2, which has been uploaded as a 
binary to `binaries.cockroachdb.com`. This new version update includes 
no breaking changes, and just adds telemetry that can be disabled using 
the `ccloud settings` commands.

Release note: `ccloud` is updated to `v0.2.2` to include optional telemetry.