### PR TITLE
ccloud: update ccloud sha for silent version upgrade

### DIFF
--- a/Formula/ccloud.rb
+++ b/Formula/ccloud.rb
@@ -6,7 +6,7 @@ class Ccloud < Formula
   homepage "https://www.cockroachlabs.com"
   url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.2.2.tar.gz"
   version "0.2.2"
-  sha256 "6793f246805c6c4909de9dca47e8d88a0e7af72cca41087da86065f92684ccbb"
+  sha256 "043b4d9a719d0bd09ccd51cf4c539655dc4b31380bd6396f259130eb9862ace4"
 
   def install
     bin.install "ccloud"


### PR DESCRIPTION
This PR updates the 2.2 patch silently due to a non 
breaking change of a telemetry event, specifically 
adding an `Initiated` event type for when certain 
multi step commands are run.

Release note: None