### PR TITLE
ccloud: bump ccloud to 0.2.5

### DIFF
--- a/Formula/ccloud.rb
+++ b/Formula/ccloud.rb
@@ -4,9 +4,9 @@
 class Ccloud < Formula
   desc "CockroachDB Cloud CLI"
   homepage "https://www.cockroachlabs.com"
-  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.2.4.tar.gz"
-  version "0.2.4"
-  sha256 "53d3115c097fc38d7153fefc84298abe0c64e4247a5b7e175be8aae376034719"
+  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.2.5.tar.gz"
+  version "0.2.5"
+  sha256 "e2a64f7a8f76812d9a08cd029452262e70717f448adb75e0f50733f8ff25e544"
 
   def install
     bin.install "ccloud"
@@ -14,7 +14,7 @@ class Ccloud < Formula
 
   test do
     output = shell_output("#{bin}/ccloud version", 0)
-    assert_match "ccloud 0.2.4", output
+    assert_match "ccloud 0.2.5", output
   end
 end
 


### PR DESCRIPTION
This update just includes some updated error telemetry.

Release note: None