### PR TITLE
ccloud: bump ccloud to 0.3.6

### DIFF
--- a/Formula/ccloud.rb
+++ b/Formula/ccloud.rb
@@ -4,9 +4,9 @@
 class Ccloud < Formula
   desc "CockroachDB Cloud CLI"
   homepage "https://www.cockroachlabs.com"
-  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.2.5.tar.gz"
-  version "0.2.5"
-  sha256 "e2a64f7a8f76812d9a08cd029452262e70717f448adb75e0f50733f8ff25e544"
+  version "0.3.6"
+  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.3.6.tar.gz"
+  sha256 "726f370941e14bab9478a29923f33529ad357b49f9431d813477472259554cff"
 
   def install
     bin.install "ccloud"
@@ -14,7 +14,7 @@ class Ccloud < Formula
 
   test do
     output = shell_output("#{bin}/ccloud version", 0)
-    assert_match "ccloud 0.2.5", output
+    assert_match "ccloud 0.3.6", output
   end
 end
 


### PR DESCRIPTION
This update includes the changes needed for Cloud Cluster SSO and allows users to run `ccloud auth login` remotely.

Release note: None