### PR TITLE
ccloud: bump ccloud to 0.3.7

### DIFF
--- a/Formula/ccloud.rb
+++ b/Formula/ccloud.rb
@@ -4,9 +4,9 @@
 class Ccloud < Formula
   desc "CockroachDB Cloud CLI"
   homepage "https://www.cockroachlabs.com"
-  version "0.3.6"
-  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.3.6.tar.gz"
-  sha256 "726f370941e14bab9478a29923f33529ad357b49f9431d813477472259554cff"
+  version "0.3.7"
+  url "https://binaries.cockroachdb.com/ccloud/ccloud_darwin-amd64_0.3.7.tar.gz"
+  sha256 "a0999ec88afb762da7686797d0ac910c38ba13851c1e10946277e28aa0eb3051"
 
   def install
     bin.install "ccloud"
@@ -14,7 +14,7 @@ class Ccloud < Formula
 
   test do
     output = shell_output("#{bin}/ccloud version", 0)
-    assert_match "ccloud 0.3.6", output
+    assert_match "ccloud 0.3.7", output
   end
 end
 


### PR DESCRIPTION
The updated version allows cluster SSO for serverless clusters and lets ccloud auth work with Safari without downloading a file.

Release note: None