### PR TITLE
Use service instead of deprecated plist_options

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -59,36 +59,12 @@ class Cockroach < Formula
   EOS
   end
 
-  plist_options :manual => "cockroach start-single-node --insecure --http-port=26256 --host=localhost"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/cockroach</string>
-        <string>start-single-node</string>
-        <string>--store=#{var}/cockroach/</string>
-        <string>--spatial-libs=#{lib}/cockroach</string>
-        <string>--http-port=26256</string>
-        <string>--insecure</string>
-        <string>--host=localhost</string>
-      </array>
-      <key>WorkingDirectory</key>
-      <string>#{var}</string>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <true/>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [bin/"cockroach", "start-single-node", "--insecure", "--http-port=26256", "--host=localhost"]
+    keep_alive true
+    working_dir var
   end
-
+  
   test do
     begin
       # Redirect stdout and stderr to a file, or else  `brew test --verbose`

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -76,7 +76,7 @@ class Cockroach < Formula
     log_path var/"log/cockroach.log"
     error_log_path var/"log/cockroach.err"
   end
-  
+
   test do
     begin
       # Redirect stdout and stderr to a file, or else  `brew test --verbose`

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -60,9 +60,21 @@ class Cockroach < Formula
   end
 
   service do
-    run [bin/"cockroach", "start-single-node", "--insecure", "--http-port=26256", "--host=localhost"]
-    keep_alive true
+    args = [
+      "start-single-node",
+      "--store=#{var}/cockroach",
+      "--http-port=26256",
+      "--insecure",
+      "--host=localhost",
+     ]
+    if !(OS.mac? && Hardware::CPU.arm?)
+      args << "--spatial-libs=#{opt_bin}/../lib/cockroach"
+    end
+    run [opt_bin/"cockroach"] + args
     working_dir var
+    keep_alive true
+    log_path var/"log/cockroach.log"
+    error_log_path var/"log/cockroach.err"
   end
   
   test do
@@ -109,4 +121,3 @@ class Cockroach < Formula
     end
   end
 end
-

--- a/release/cockroach-tmpl.rb
+++ b/release/cockroach-tmpl.rb
@@ -59,34 +59,22 @@ class Cockroach < Formula
   EOS
   end
 
-  plist_options :manual => "cockroach start-single-node --insecure --http-port=26256 --host=localhost"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/cockroach</string>
-        <string>start-single-node</string>
-        <string>--store=#{var}/cockroach/</string>
-        <string>--spatial-libs=#{lib}/cockroach</string>
-        <string>--http-port=26256</string>
-        <string>--insecure</string>
-        <string>--host=localhost</string>
-      </array>
-      <key>WorkingDirectory</key>
-      <string>#{var}</string>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <true/>
-    </dict>
-    </plist>
-  EOS
+  service do
+    args = [
+      "start-single-node",
+      "--store=#{var}/cockroach",
+      "--http-port=26256",
+      "--insecure",
+      "--host=localhost",
+     ]
+    if !(OS.mac? && Hardware::CPU.arm?)
+      args << "--spatial-libs=#{opt_bin}/../lib/cockroach"
+    end
+    run [opt_bin/"cockroach"] + args
+    working_dir var
+    keep_alive true
+    log_path var/"log/cockroach.log"
+    error_log_path var/"log/cockroach.err"
   end
 
   test do


### PR DESCRIPTION
Fixing this warning message:

```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the cockroachdb/tap tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/cockroachdb/homebrew-tap/Formula/cockroach.rb:62
```