### PR TITLE
add @22.2 build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,15 @@ jobs:
       run: brew install ./Formula/cockroach.rb
     - name: test cockroach formula
       run: brew test ./Formula/cockroach.rb
+  cockroach-222-test:
+    name: cockroach@22.2 formula tests
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install cockroach formula
+        run: brew install ./Formula/cockroach@22.2.rb
+      - name: test cockroach formula
+        run: brew test ./Formula/cockroach@22.2.rb
   cockroach-sql-test:
     name: cockroach-sql formula tests
     runs-on: macos-latest

--- a/Formula/cockroach@22.2.rb
+++ b/Formula/cockroach@22.2.rb
@@ -1,18 +1,18 @@
 # Auto-generated file, DO NOT EDIT
 # Source: release/cockroach-tmpl.rb
 
-class Cockroach{{ .ClassSuffix }} < Formula
+class CockroachAT222 < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "{{ .Version }}"
+  version "22.2.11"
   on_macos do
     on_intel do
-      url "{{ .IntelURL }}"
-      sha256 "{{ .IntelSHA256 }}"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.11.darwin-10.9-amd64.tgz"
+      sha256 "37ae1d5c39e8767dc578a8b64901dad027404f21e32d1ff9532b4c493806e6fe"
     end
     on_arm do
-      url "{{ .ARMURL }}"
-      sha256 "{{ .ARMSHA256 }}"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.11.darwin-11.0-arm64.tgz"
+      sha256 "f3608868b229c6fea574032fa1279b20c1bd6ace24e76bbd424ff6d67fba740b"
     end
   end
 
@@ -123,3 +123,4 @@ class Cockroach{{ .ClassSuffix }} < Formula
     end
   end
 end
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is the official source for installing CockroachDB, CockroachDB SQL CLI, and
 
 ```shell
 $ brew install cockroachdb/tap/cockroach
+$ brew install cockroachdb/tap/cockroach@22.2 # for older versions
 $ brew install cockroachdb/tap/cockroach-sql
 $ brew install cockroachdb/tap/ccloud
 ```


### PR DESCRIPTION
This allows homebrew to install older cockroach versions using the same brew syntax.

I didn't do the earlier versions as they have no ARM versions, and would require a large template change.

Refs #42