### PR TITLE
add alias for cockroach v23.1

### DIFF
--- a/Aliases/cockroach@23.1
+++ b/Aliases/cockroach@23.1
@@ -1,0 +1,1 @@
+../Formula/cockroach.rb


### PR DESCRIPTION
This currently aliases to cockroach using a symlink.
This is how it's done in the homebrew repo.

