### PR TITLE
build: fix template usage in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,5 @@ endif
 generate:
 	bazel build //release && \
 	  $$(bazel info bazel-bin)/release/release_/release \
-	  $(PRODUCT) $(VERSION) release/$(PRODUCT)-tmpl.rb > Formula/$(PRODUCT).rb.tmp && \
+	  $(PRODUCT) $(VERSION) release/$(firstword $(subst @, ,$(PRODUCT)))-tmpl.rb > Formula/$(PRODUCT).rb.tmp && \
 	  mv Formula/$(PRODUCT).rb.tmp Formula/$(PRODUCT).rb


### PR DESCRIPTION
Now that we can use the same template to generate `cockroach.rb` and `cockroach@22.2.rb`, we should also update the helper Makefile to use the same template for them.