### PR TITLE
release: advance CRDB version to v23.1.6 + v22.2.12

### DIFF
--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,15 +4,15 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.5"
+  version "23.1.6"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.5.darwin-10.9-amd64.tgz"
-      sha256 "1b8d887175f219095673679ba4d4d5fb48deea523c873f3b367f3b95ab1a26ff"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.6.darwin-10.9-amd64.tgz"
+      sha256 "45537525e9d75bc85b114739fbfecd35ea312ce16ba3729972bc602b60cc6842"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.5.darwin-11.0-arm64.tgz"
-      sha256 "7fe05f3537c1bce7bf5dc66c740679d4c0c7068c875f6e7ad32ad54850e41c6f"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.6.darwin-11.0-arm64.tgz"
+      sha256 "63c0dfb1ea4c72a569e4df560da1f5e6d0965c1f5c3a9921aff6415e4f0de2e8"
     end
   end
 
@@ -22,7 +22,7 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version", 0)
-    assert_match "23.1.5", output
+    assert_match "23.1.6", output
   end
 
 end

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,15 +4,15 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "23.1.5"
+  version "23.1.6"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.5.darwin-10.9-amd64.tgz"
-      sha256 "0dffc9cf34497d13a3e25db3aca1da430461f2b99f2264e80c2557c76c831b54"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.6.darwin-10.9-amd64.tgz"
+      sha256 "f8527361e9d395142277797bf010059e4cff4837d13c8c1e13a9c3b7c29fb8a3"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v23.1.5.darwin-11.0-arm64.tgz"
-      sha256 "7950eb48c669682fe3500f47b9404e0b7fa2f30134ee861f90bb20f2d01fa922"
+      url "https://binaries.cockroachdb.com/cockroach-v23.1.6.darwin-11.0-arm64.tgz"
+      sha256 "f998bf53fb57da5971d5c86350f3a00c2abedf113fbd525e1c7ee0ea986195e7"
     end
   end
 

--- a/Formula/cockroach@22.2.rb
+++ b/Formula/cockroach@22.2.rb
@@ -4,15 +4,15 @@
 class CockroachAT222 < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "22.2.11"
+  version "22.2.12"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.11.darwin-10.9-amd64.tgz"
-      sha256 "37ae1d5c39e8767dc578a8b64901dad027404f21e32d1ff9532b4c493806e6fe"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.12.darwin-10.9-amd64.tgz"
+      sha256 "8643f2dbd5c0f4d92c5510c750f1454f26f5a067cd2ecef535c46116446b16b7"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v22.2.11.darwin-11.0-arm64.tgz"
-      sha256 "f3608868b229c6fea574032fa1279b20c1bd6ace24e76bbd424ff6d67fba740b"
+      url "https://binaries.cockroachdb.com/cockroach-v22.2.12.darwin-11.0-arm64.tgz"
+      sha256 "0d2aff9fec8779aaf0916fb71d57d6c025a9c4198962b937ca2c8b94e0459a3a"
     end
   end
 


### PR DESCRIPTION
This includes both v23.1.6 + v22.2.12