### PR TITLE
add linux support to cockroach-sql

### DIFF
--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -5,6 +5,10 @@ class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
   version "23.1.11"
+  on_linux do
+    url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.11.linux-amd64.tgz"
+    sha256 "8a42076aa8d4448820eb47d9816d08f110d830b263e7edfab1e57f354e6817bb"
+  end
   on_macos do
     on_intel do
       url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.11.darwin-10.9-amd64.tgz"

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -40,6 +40,24 @@ class Cockroach < Formula
         "#{lib}/cockroach/libgeos_c.dylib"
     end
 
+    on_linux do
+      lib.mkpath
+      mkdir "#{lib}/cockroach"
+      lib.install "lib/libgeos.dylib" => "cockroach/libgeos.dylib"
+      lib.install "lib/libgeos_c.dylib" => "cockroach/libgeos_c.dylib"
+
+      # Brew sets rpaths appropriately, but only if the rpaths are set
+      # to not include "@rpath". As such, use the #{lib} location for the
+      # rpaths.
+      system "install_name_tool", "-id",
+        "#{lib}/cockroach/libgeos.dylib", "#{lib}/cockroach/libgeos.dylib"
+      system "install_name_tool", "-id",
+        "#{lib}/cockroach/libgeos_c.1.dylib", "#{lib}/cockroach/libgeos_c.dylib"
+      system "install_name_tool", "-change",
+        "@rpath/libgeos.3.8.1.dylib", "#{lib}/cockroach/libgeos.dylib",
+        "#{lib}/cockroach/libgeos_c.dylib"
+    end
+
     system "#{bin}/cockroach", "gen", "man", "--path=#{man1}"
 
     bash_completion.mkpath

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -5,6 +5,10 @@ class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
   version "23.1.11"
+  on_linux do
+    url "https://binaries.cockroachdb.com/cockroach-v23.1.11.linux-amd64.tgz"
+    sha256 "918568da921a6e7b3033cef77eda09656cd4dcbc5602916f652bbfab7c6f8d67"
+  end
   on_macos do
     on_intel do
       url "https://binaries.cockroachdb.com/cockroach-v23.1.11.darwin-10.9-amd64.tgz"


### PR DESCRIPTION
Hi,

I noticed that these formulae only support MacOS.  I use Linux.  I tested this out on ubuntu-22.04 and it works like a charm.  Can you look at adding Linux support to all of the formulae in this repo?

Thanks!
Mark