### PR TITLE
add linux support

### DIFF
--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -5,6 +5,10 @@ class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
   version "23.1.11"
+  on_linux do
+    url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.11.linux-amd64.tgz"
+    sha256 "8a42076aa8d4448820eb47d9816d08f110d830b263e7edfab1e57f354e6817bb"
+  end
   on_macos do
     on_intel do
       url "https://binaries.cockroachdb.com/cockroach-sql-v23.1.11.darwin-10.9-amd64.tgz"


### PR DESCRIPTION
Hi,

I noticed that these formulae only support MacOS. I use Linux. I tested this out on ubuntu-22.04 and it works like a charm.  I tried doing something similar with `cockroach` and unfortunately it wasn't so easy because of the extra stuff that cockroach does for GEOS support.   It'd be great if there was Linux support for all of the formulae in this repo.  I'm happy to open an issue to track that need if you'd like.

Thanks!
Mark