### PR TITLE
Remove license version constraints

### DIFF
--- a/release/cockroach-sql-tmpl.rb
+++ b/release/cockroach-sql-tmpl.rb
@@ -18,9 +18,7 @@ class CockroachSql < Formula
 
   def install
     bin.install "cockroach-sql"
-    if version >= Version::new("24.1.0")
-      prefix.install "LICENSE.txt", "THIRD-PARTY-NOTICES.txt"
-    end
+    prefix.install "LICENSE.txt", "THIRD-PARTY-NOTICES.txt"
   end
 
   test do

--- a/release/cockroach-tmpl.rb
+++ b/release/cockroach-tmpl.rb
@@ -18,9 +18,7 @@ class Cockroach{{ .ClassSuffix }} < Formula
 
   def install
     bin.install "cockroach"
-    if version >= Version::new("24.1.0")
-      prefix.install "LICENSE.txt", "THIRD-PARTY-NOTICES.txt"
-    end
+    prefix.install "LICENSE.txt", "THIRD-PARTY-NOTICES.txt"
     on_intel do
       lib.mkpath
       mkdir "#{lib}/cockroach"


### PR DESCRIPTION
This pr removes the version constraint to install the license files. It will not affect the current versions, only the formulas that will be regenerated as a part of the next releases.