### PR TITLE
Remove alias

### DIFF
--- a/Aliases/cockroach@23.1
+++ b/Aliases/cockroach@23.1
@@ -1,1 +1,0 @@
-../Formula/cockroach.rb


### PR DESCRIPTION
We do not use aliases to point to the latest version (`cockroach -> cockroach@24.1`), instead, we just update `cockroach.rb` and create `cockroach@x.y` for older versions.