### PR TITLE
Automege crl-release-eng-bot PRs

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'cockroach-teamcity' }}
+    if: ${{ github.actor == 'cockroach-teamcity' || github.actor == 'crl-release-eng-bot' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This account is used to create version bump PRs in the new release automation process.