### PR TITLE
release: advance cockroach and cockroach-sql to v26.2.3

### DIFF
--- a/Formula/cockroach-sql.rb
+++ b/Formula/cockroach-sql.rb
@@ -4,23 +4,23 @@
 class CockroachSql < Formula
   desc "Distributed SQL database shell"
   homepage "https://www.cockroachlabs.com"
-  version "26.2.2"
+  version "26.2.3"
 
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v26.2.2.darwin-10.9-amd64.tgz"
-      sha256 "d63a547e7596fa3e6f427058ec1b210e4d118e8182cdc8cb838c50b4ee9fc359"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v26.2.3.darwin-10.9-amd64.tgz"
+      sha256 "2b5b329c8a7cdb40ccf232a123455c5ce51ff464217360853df2fa0494f12ba3"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v26.2.2.darwin-11.0-arm64.tgz"
-      sha256 "eea84d5ec43f0d80fcd82399e3659d610df0c00a973dfc020b6e832208df9d55"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v26.2.3.darwin-11.0-arm64.tgz"
+      sha256 "a584c3156cf532a559ba2175b2dcea983029470bd2b4b012590d4d5d0a05e04b"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-sql-v26.2.2.linux-amd64.tgz"
-      sha256 "abab9881ebb4afdfa3e10ade1cefa857e762340b36af7b61056b5bc87ce94777"
+      url "https://binaries.cockroachdb.com/cockroach-sql-v26.2.3.linux-amd64.tgz"
+      sha256 "b917799627b9da4f21532e248ce7f859c6ede7bbda2777110209d15ae9d7d386"
     end
   end
 
@@ -33,6 +33,6 @@ class CockroachSql < Formula
 
   test do
     output = shell_output("#{bin}/cockroach-sql --version")
-    assert_match "26.2.2", output
+    assert_match "26.2.3", output
   end
 end

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,22 +4,22 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "26.2.2"
+  version "26.2.3"
   on_macos do
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v26.2.2.darwin-10.9-amd64.tgz"
-      sha256 "67b1638f24be548a680236854f4586ee2188a05debb2c4db95633e526adc4398"
+      url "https://binaries.cockroachdb.com/cockroach-v26.2.3.darwin-10.9-amd64.tgz"
+      sha256 "5b37d64461d0892f23c2e3f5f77050994085e08899c9a354afc3c60c05290cea"
     end
     on_arm do
-      url "https://binaries.cockroachdb.com/cockroach-v26.2.2.darwin-11.0-arm64.tgz"
-      sha256 "2e73ffc6c7f51cda763878550ae184209c868c3033477bf1ce824220b893331c"
+      url "https://binaries.cockroachdb.com/cockroach-v26.2.3.darwin-11.0-arm64.tgz"
+      sha256 "7dc16bcc3d30a076e213736b3748d3baef3f714cd06769534bc0b8d05c71d670"
     end
   end
   on_linux do
     depends_on "patchelf" => :install
     on_intel do
-      url "https://binaries.cockroachdb.com/cockroach-v26.2.2.linux-amd64.tgz"
-      sha256 "f712fa7db100a7da301000e7991f90ebf48890ea6064a842c8c4e9ca01d510f2"
+      url "https://binaries.cockroachdb.com/cockroach-v26.2.3.linux-amd64.tgz"
+      sha256 "3eca6d7bc6fefa3ba0847e89733fc69f61226c80b8fab0af6578e1be672f27d3"
     end
   end
 


### PR DESCRIPTION
Bumps the `cockroach` and `cockroach-sql` (latest) formulas to v26.2.3.

v26.2.3 is the latest stable release, so the unversioned formulas should track it. The release pipeline skipped these because it computed `isLatest=false` (it also failed to open the homebrew-tap PR entirely; the versioned `cockroach@26.2` bump was recreated in #400). Formulas regenerated via `make PRODUCT=cockroach VERSION=26.2.3` and `make PRODUCT=cockroach-sql VERSION=26.2.3`.